### PR TITLE
fix(api): default API to port 4000 for dev

### DIFF
--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -6,7 +6,7 @@ import { validateRequest, PreviewDto } from "./dto.js";
 import { MemoryQuoteRepository } from "./quotes/quote.repo.memory.js";
 
 const app = express();
-const PORT = process.env.PORT || 3000;  // keep 3000 since your Codespace shows port 3000 running
+const PORT = process.env.PORT || 4000;
 
 // Enable CORS
 app.use(cors({
@@ -126,5 +126,5 @@ app.get("/quotes/:id/preview-newer", async (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`[QCSv1 API] listening on http://localhost:${PORT}`);
+  console.log(`API running on port ${PORT}`);
 });


### PR DESCRIPTION
API now defaults to port 4000 instead of 3000.

Prevents collisions with Next.js dev server on 3000.

./dev.sh should start both services cleanly.

Follow-up: Homer smoke test.